### PR TITLE
Remove mocking scope to simplify mocking

### DIFF
--- a/src/failed.js
+++ b/src/failed.js
@@ -1,6 +1,6 @@
 'use strict'
 
-function instantiate (message, cause, context, name = 'Error') {
+function fail (message, cause, context, name = 'Error') {
   const e = new Error(message)
   e.name = name
   if (cause) e.cause = () => cause
@@ -25,11 +25,11 @@ module.exports.query = (pgError, context) => {
     if (pgError[k]) cause.context[k] = pgError[k]
   })
   delete cause.context.name
-  return instantiate(pgError.message, cause, context, 'QueryFailed')
+  return fail(pgError.message, cause, context, 'QueryFailed')
 }
 
 module.exports.mock = (name, mockError, context) => {
-  return instantiate(
+  return fail(
     `Mock ${name}() threw error`,
     mockError,
     context,
@@ -40,7 +40,7 @@ module.exports.mock = (name, mockError, context) => {
 module.exports.result = (message, result, context) => {
   const cause = new Error(message)
   cause.context = {result}
-  return instantiate(
+  return fail(
     'incorrect result from mock',
     cause,
     context,

--- a/src/index.js
+++ b/src/index.js
@@ -71,6 +71,24 @@ class Link {
 Link.log = new DebugLog()
 
 class PgLink extends Link {
+  static mock () {
+    const MockLink = class extends Link {
+      static clearMocks () {
+        for (let name of Object.keys(this.fn)) {
+          delete this.fn[name]
+        }
+      }
+
+      constructor (url, ...segments) {
+        const directory = checkLinkArgs(url, segments)
+        const strategy = new MockStrategy(url, directory, MockLink.fn)
+        super(strategy)
+      }
+    }
+    MockLink.fn = {}
+    return MockLink
+  }
+
   constructor (url, ...segments) {
     const directory = checkLinkArgs(url, segments)
     super(new PgStrategy(url, directory))
@@ -93,25 +111,6 @@ class Handler {
     if (name in target) return target[name]
     if (name in this.strategy.methods) return this.strategy.methods[name]
     return this.strategy.create(name)
-  }
-}
-
-class MockingScope {
-  constructor () {
-    const fn = (this.fn = {})
-    this.Link = class extends Link {
-      constructor (url, ...segments) {
-        const directory = checkLinkArgs(url, segments)
-        const strategy = new MockStrategy(url, directory, fn)
-        super(strategy)
-      }
-    }
-  }
-
-  clearMocks () {
-    for (let name of Object.keys(this.fn)) {
-      delete this.fn[name]
-    }
   }
 }
 

--- a/src/pg.js
+++ b/src/pg.js
@@ -61,7 +61,6 @@ class PgStrategy extends BaseStrategy {
     const method = function () {
       const elapsed = time.start()
       const args = [...arguments].map(format)
-      debugger
       const context = {arguments: args}
       Object.assign(context, meta)
       Error.captureStackTrace(context, method)

--- a/src/pg.js
+++ b/src/pg.js
@@ -61,6 +61,7 @@ class PgStrategy extends BaseStrategy {
     const method = function () {
       const elapsed = time.start()
       const args = [...arguments].map(format)
+      debugger
       const context = {arguments: args}
       Object.assign(context, meta)
       Error.captureStackTrace(context, method)

--- a/test/lib/common.js
+++ b/test/lib/common.js
@@ -10,14 +10,14 @@ module.exports = test => {
 
   test('exposes existence of functions', t => {
     t.plan(1)
-    t.context.mock.fn.selectInteger = 42
+    t.context.Link.fn.selectInteger = 42
     return t.context.db.connect(c => {
       t.true('selectInteger' in c)
     })
   })
 
   test('executes value function', t => {
-    t.context.mock.fn.selectInteger = 43
+    t.context.Link.fn.selectInteger = 43
     return t.context.db
       .connect(c => {
         return c.selectInteger(43)
@@ -28,7 +28,7 @@ module.exports = test => {
   })
 
   test('executes a row function', t => {
-    t.context.mock.fn.selectIntegerAndString = {number: 42, str: 'abc'}
+    t.context.Link.fn.selectIntegerAndString = {number: 42, str: 'abc'}
     return t.context.db
       .connect(c => {
         return c.selectIntegerAndString(42, 'abc')
@@ -40,7 +40,7 @@ module.exports = test => {
   })
 
   test('executes a table function', t => {
-    t.context.mock.fn.selectSeries = [
+    t.context.Link.fn.selectSeries = [
       {num: 0},
       {num: 1},
       {num: 2},
@@ -65,7 +65,7 @@ module.exports = test => {
   })
 
   test('executes a result function', t => {
-    t.context.mock.fn.selectResult = {
+    t.context.Link.fn.selectResult = {
       command: 'SELECT',
       rowCount: 9,
       rows: [
@@ -96,7 +96,7 @@ module.exports = test => {
   })
 
   test('executes queries in parallel', t => {
-    t.context.mock.fn.selectInteger = 3
+    t.context.Link.fn.selectInteger = 3
     return t.context.db
       .all(
         c => c.selectInteger(3),
@@ -111,10 +111,10 @@ module.exports = test => {
   })
 
   test('executes queries in a transaction', t => {
-    const {mock, db} = t.context
-    mock.fn.insertN = () => {}
-    mock.fn.zeroN = () => {}
-    mock.fn.sumN = 42
+    const {Link, db} = t.context
+    Link.fn.insertN = () => {}
+    Link.fn.zeroN = () => {}
+    Link.fn.sumN = 42
     return db.txn(one => {
       return one
         .insertN(42)
@@ -131,8 +131,8 @@ module.exports = test => {
   })
 
   test('automatically rolls back transactions', t => {
-    const {db, mock} = t.context
-    t.context.mock.fn.error = () => {
+    const {db, Link} = t.context
+    t.context.Link.fn.error = () => {
       throw new Error('column "this_column_doesnt_exist" does not exist')
     }
     return t.context.db
@@ -152,9 +152,9 @@ module.exports = test => {
   })
 
   test('QueryFailed includes context', t => {
-    const {mock, db} = t.context
+    const {db, Link} = t.context
 
-    mock.fn.errorWithArguments = () => {
+    Link.fn.errorWithArguments = () => {
       throw new Error('whiffle')
     }
     return db.connect(c => c.errorWithArguments(42, 21, 96)).catch(e => {

--- a/test/mock.js
+++ b/test/mock.js
@@ -3,14 +3,14 @@ const Link = require('../src')
 const common = require('./lib/common')
 
 test.beforeEach(t => {
-  t.context.mock = Link.mock()
-  t.context.db = new t.context.mock.Link('pg:///test', __dirname, 'sql')
+  t.context.Link = Link.mock()
+  t.context.db = new t.context.Link('pg:///test', __dirname, 'sql')
 })
 
 common(test)
 
 test('rejects a table mock that is not an array', t => {
-  t.context.mock.fn.selectSeries = 42
+  t.context.Link.fn.selectSeries = 42
   return t.context.db.connect(sql => sql.selectSeries(8)).catch(e => {
     t.is(e.name, 'QueryFailed')
     t.is(e.message, 'incorrect result from mock')
@@ -20,7 +20,7 @@ test('rejects a table mock that is not an array', t => {
 })
 
 test('rejects a table mock that does not contain rows', t => {
-  t.context.mock.fn.selectSeries = [42]
+  t.context.Link.fn.selectSeries = [42]
   return t.context.db.connect(sql => sql.selectSeries(8)).catch(e => {
     t.is(e.name, 'QueryFailed')
     t.is(e.message, 'incorrect result from mock')
@@ -30,7 +30,7 @@ test('rejects a table mock that does not contain rows', t => {
 })
 
 test('rejects a row mock that does not return a row', t => {
-  t.context.mock.fn.selectIntegerAndString = 42
+  t.context.Link.fn.selectIntegerAndString = 42
   return t.context.db.connect(sql => sql.selectIntegerAndString(8)).catch(e => {
     t.is(e.name, 'QueryFailed')
     t.is(e.message, 'incorrect result from mock')
@@ -40,7 +40,7 @@ test('rejects a row mock that does not return a row', t => {
 })
 
 test('rejects a row mock that returns a row with no columns', t => {
-  t.context.mock.fn.selectIntegerAndString = {}
+  t.context.Link.fn.selectIntegerAndString = {}
   return t.context.db.connect(sql => sql.selectIntegerAndString(8)).catch(e => {
     t.is(e.name, 'QueryFailed')
     t.is(e.message, 'incorrect result from mock')
@@ -50,15 +50,15 @@ test('rejects a row mock that returns a row with no columns', t => {
 })
 
 test('accepts a undefined mock row', t => {
-  t.context.mock.fn.selectIntegerAndString = undefined
+  t.context.Link.fn.selectIntegerAndString = undefined
   return t.context.db
     .connect(sql => sql.selectIntegerAndString(8))
     .then(row => t.true(row === undefined))
 })
 
 test('includes the error name and message in the stack', t => {
-  const {mock, db} = t.context
-  mock.fn.errorWithArguments = () => {
+  const {db, Link} = t.context
+  Link.fn.errorWithArguments = () => {
     throw new Error('whiffle')
   }
   return db.connect(sql => sql.errorWithArguments(42, 21, 96)).catch(e => {
@@ -69,11 +69,11 @@ test('includes the error name and message in the stack', t => {
 })
 
 test('clears mocks', t => {
-  const {mock, db} = t.context
-  mock.fn.nurp = () => {
+  const {db, Link} = t.context
+  Link.fn.nurp = () => {
     t.fail('should never be called')
   }
-  mock.clearMocks()
+  Link.clearMocks()
   return db
     .connect(sql => sql.nurp())
     .then(


### PR DESCRIPTION
This simplifies mocking for tests. 

Instead of `mock()` returning a "mocking scope", it just returns a mock Link class, which has a static `fn` object for installing mock queries, and a static `clearMocks()` method.