### PR TITLE
Mocks inherit the log from PgLink by default

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -86,6 +86,7 @@ class PgLink extends Link {
       }
     }
     MockLink.fn = {}
+    if ('log' in PgLink) MockLink.log = PgLink.log
     return MockLink
   }
 


### PR DESCRIPTION
This makes it easier to view logs when running tests. 