### PR TITLE
Remove anonymous class around object.

### DIFF
--- a/src/pg.js
+++ b/src/pg.js
@@ -87,10 +87,10 @@ class PgStrategy extends BaseStrategy {
         }
         break
       case 'row':
-        fn = r => Object.assign({}, r.rows[0])
+        fn = r => r.rows[0] ? Object.assign({}, r.rows[0]) : r.rows[0]
         break
       case 'table':
-        fn = r => r.rows.map(ea => Object.assign({}, ea))
+        fn = r => r.rows.map(ea => ea ? Object.assign({}, ea) : ea)
         break
       case undefined:
         fn = result => result

--- a/src/pg.js
+++ b/src/pg.js
@@ -87,10 +87,10 @@ class PgStrategy extends BaseStrategy {
         }
         break
       case 'row':
-        fn = r => r.rows[0]
+        fn = r => Object.assign({}, r.rows[0])
         break
       case 'table':
-        fn = r => r.rows
+        fn = r => r.rows.map(ea => Object.assign({}, ea))
         break
       case undefined:
         fn = result => result


### PR DESCRIPTION
node-postgres seems to be creating an "anonymous function" class for the objects it returns. This makes everything from deepEquals in tests to some of the stuff we're doing in the UID module fail. You can find more info on what seems to be going on with this here: https://github.com/brianc/node-postgres/issues/1062